### PR TITLE
aws-eks: improved configurations and permissions 

### DIFF
--- a/.forms.yml
+++ b/.forms.yml
@@ -210,12 +210,18 @@ aws-eks:
         values:
              - "ondemand"
              - "spot"
-      - name: "Spot price"
-        description: "EKS nodes spot price when `node_market_type = spot`."
+      - name: "Spot instance request type"
+        description: "EKS nodes spot request type when `node_market_type = spot`. Can be either `one-time`, `persistent` or left undefined."
+        key: module.eks-node.node_spot_request_type
+        widget: simple_text
+        type: string
+        default: ""
+      - name: "Spot instance max price"
+        description: "EKS nodes max spot price when `node_market_type = spot`. Undefined by default."
         key: module.eks-node.node_spot_price
         widget: simple_text
         type: string
-        default: "0.3"
+        default: ""
       - name: "Enable Cluster Autoscaler"
         description: "Should be true to add Cluster Autoscaler ASG tags."
         key: module.eks-node.node_enable_cluster_autoscaler_tags

--- a/.forms.yml
+++ b/.forms.yml
@@ -106,6 +106,12 @@ aws-eks:
         type: array
         default:
             - "0.0.0.0/0"
+      - name: "AWS IAM role ARN to map as admin"
+        description: "AWS IAM role ARN to map as system:masters within the Kubernetes cluster. By default, a default arbitrary role called 'admin' will be allowed."
+        key: module.eks.eks_admin_iam_role_arn
+        widget: simple_text
+        type: string
+        default: ""
 
     eks-node:
       - name: "SSH keypair"
@@ -220,7 +226,7 @@ aws-eks:
 azure-aks:
   pipeline:
     Terraform:
-      - name: "Azure Subscription ID" 
+      - name: "Azure Subscription ID"
         description: "Azure subscription ID to use for Terraform."
         key: azure_subscription_id
         widget: cy_cred
@@ -237,20 +243,20 @@ azure-aks:
         key: azure_client_id
         widget: cy_cred
         type: string
-        default: "((azure_admin.client_id))"    
+        default: "((azure_admin.client_id))"
       - name: "Azure Client Secret"
         description: "Azure Client Secret to use for Terraform."
         key: azure_client_secret
         widget: cy_cred
         type: string
-        default: "((azure_admin.client_secret))" 
+        default: "((azure_admin.client_secret))"
       - name: "Azure Location"
         description: "Azure location to use for Terraform."
         key: azure_location
         widget: auto_complete
         type: string
         values: ["North Europe","West Europe","France Central","France South"]
-        default: "West Europe" 
+        default: "West Europe"
       - name: "Azure Resource Group of the Storage Account"
         description: "Azure Resource Group of the Storage Account to use to store terraform remote state file."
         key: terraform_resource_group_name
@@ -319,7 +325,7 @@ azure-aks:
         description: "The branch used by the config repository"
         source: config_git_repository
         default: "master"
-        required: true  
+        required: true
 
   terraform:
     config:
@@ -335,7 +341,7 @@ azure-aks:
         widget: simple_text
         type: string
         default: "($ project $)-($ environment $)"
-        
+
     vpc:
       - name: "Address Space"
         description: "The virtual network address space."
@@ -533,7 +539,7 @@ scaleway-kapsule:
         widget: auto_complete
         type: string
         values: ["fr-par","nl-ams","pl-waw"]
-        default: fr-par        
+        default: fr-par
       - name: "Terraform storage bucket"
         description: "Object Storage Bucket name to store terraform remote state file."
         key: terraform_storage_bucket_name
@@ -574,7 +580,7 @@ scaleway-kapsule:
         widget: simple_text
         type: string
         default: "($ project $)-($ environment $)"
- 
+
     kapsule:
       - name: "Cluster version"
         description: "Kapsule cluster version."
@@ -627,7 +633,7 @@ scaleway-kapsule:
             - "monday"
             - "tuesday"
             - "wednesday"
-            - "thursday" 
+            - "thursday"
             - "friday"
             - "saturday"
             - "sunday"
@@ -732,7 +738,7 @@ scaleway-nodes:
         widget: auto_complete
         type: string
         values: ["fr-par","nl-ams","pl-waw"]
-        default: fr-par        
+        default: fr-par
       - name: "Terraform storage bucket"
         description: "Object Storage Bucket name to store terraform remote state file."
         key: terraform_storage_bucket_name
@@ -836,7 +842,7 @@ scaleway-nodes:
         key: module.node_pool.placement_group_id
         widget: simple_text
         type: string
-        default: ""      
+        default: ""
       - name: "Extra tags"
         description: "Dict of extra tags to add on the pool."
         key: module.node_pool.extra_tags

--- a/terraform/aws-eks/eks.tf.sample
+++ b/terraform/aws-eks/eks.tf.sample
@@ -125,7 +125,10 @@ module "eks" {
   #+ EKS cluster enabled log types.
 
   #. control_plane_allowed_ips (optional): ["0.0.0.0/0"]
-  #+ Allow Inbound IP CIDRs to access the Kubernetes API. 
+  #+ Allow Inbound IP CIDRs to access the Kubernetes API.
+
+  #. eks_admin_iam_role_arn (optional): ""
+  #+ AWS IAM role ARN to map as system:masters within the Kubernetes cluster. By default, a default arbitrary role called 'admin' will be allowed.
 
   ###
   # Required (should probably not be touched)

--- a/terraform/aws-eks/eks.tf.sample
+++ b/terraform/aws-eks/eks.tf.sample
@@ -224,9 +224,11 @@ module "eks-node" {
   #+ EKS nodes profile, can be either `ondemand` or `spot`.
   node_launch_template_profile = "ondemand"
 
-  #. node_spot_price (optional): 0.3
-  #+ EKS nodes spot price when `node_market_type = spot`.
-  node_spot_price = 0.3
+  #. node_spot_request_type (optional): ""
+  #+ EKS nodes spot request type when `node_market_type = spot`. Can be either `one-time`, `persistent` or left undefined.
+
+  #. node_spot_price (optional): ""
+  #+ EKS nodes max spot price when `node_market_type = spot`. Undefined by default.
 
   #. node_enable_cluster_autoscaler_tags (optional): false
   #+ Should be true to add Cluster Autoscaler ASG tags.

--- a/terraform/aws-eks/module-eks-node/launch_template_ondemand.tf
+++ b/terraform/aws-eks/module-eks-node/launch_template_ondemand.tf
@@ -9,6 +9,11 @@ resource "aws_launch_template" "eks-node-ondemand" {
   user_data     = base64encode(data.template_file.user-data-eks-node.rendered)
   key_name      = var.keypair_name
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 2
+  }
+
   network_interfaces {
     associate_public_ip_address = var.node_associate_public_ip_address
     delete_on_termination       = true

--- a/terraform/aws-eks/module-eks-node/launch_template_ondemand.tf
+++ b/terraform/aws-eks/module-eks-node/launch_template_ondemand.tf
@@ -35,7 +35,9 @@ resource "aws_launch_template" "eks-node-ondemand" {
     Name                                        = "${var.project}-${var.env}-eks-node-${var.node_group_name}-template"
     role                                        = "eks-node-template"
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-    "kubernetes.io/nodegroup/name"             = "${var.node_group_name}"
+    "kubernetes.io/nodegroup/name"              = var.node_group_name
+    "eks:cluster-name"                          = var.cluster_name
+    "eks:nodegroup-name"                        = var.node_group_name
   })
 
   tag_specifications {
@@ -45,7 +47,9 @@ resource "aws_launch_template" "eks-node-ondemand" {
       Name                                        = "${var.project}-${var.env}-eks-node-${var.node_group_name}"
       role                                        = "eks-node"
       "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-      "kubernetes.io/nodegroup/name"             = "${var.node_group_name}"
+      "kubernetes.io/nodegroup/name"              = var.node_group_name
+      "eks:cluster-name"                          = var.cluster_name
+      "eks:nodegroup-name"                        = var.node_group_name
     })
   }
   tag_specifications {
@@ -55,7 +59,9 @@ resource "aws_launch_template" "eks-node-ondemand" {
       Name                                        = "${var.project}-${var.env}-eks-node-${var.node_group_name}"
       role                                        = "eks-node"
       "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-      "kubernetes.io/nodegroup/name"             = "${var.node_group_name}"
+      "kubernetes.io/nodegroup/name"              = var.node_group_name
+      "eks:cluster-name"                          = var.cluster_name
+      "eks:nodegroup-name"                        = var.node_group_name
     })
   }
 

--- a/terraform/aws-eks/module-eks-node/launch_template_spot.tf
+++ b/terraform/aws-eks/module-eks-node/launch_template_spot.tf
@@ -44,7 +44,9 @@ resource "aws_launch_template" "eks-node-spot" {
     Name                                        = "${var.project}-${var.env}-eks-node-${var.node_group_name}-template"
     role                                        = "eks-node-template"
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-    "kubernetes.io/nodegroup/name"             = "${var.node_group_name}"
+    "kubernetes.io/nodegroup/name"              = var.node_group_name
+    "eks:cluster-name"                          = var.cluster_name
+    "eks:nodegroup-name"                        = var.node_group_name
   })
 
   tag_specifications {
@@ -54,7 +56,9 @@ resource "aws_launch_template" "eks-node-spot" {
       Name                                        = "${var.project}-${var.env}-eks-node-${var.node_group_name}"
       role                                        = "eks-node"
       "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-      "kubernetes.io/nodegroup/name"             = "${var.node_group_name}"
+      "kubernetes.io/nodegroup/name"              = var.node_group_name
+      "eks:cluster-name"                          = var.cluster_name
+      "eks:nodegroup-name"                        = var.node_group_name
     })
   }
   tag_specifications {
@@ -64,7 +68,9 @@ resource "aws_launch_template" "eks-node-spot" {
       Name                                        = "${var.project}-${var.env}-eks-node-${var.node_group_name}"
       role                                        = "eks-node"
       "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-      "kubernetes.io/nodegroup/name"             = "${var.node_group_name}"
+      "kubernetes.io/nodegroup/name"              = var.node_group_name
+      "eks:cluster-name"                          = var.cluster_name
+      "eks:nodegroup-name"                        = var.node_group_name
     })
   }
 

--- a/terraform/aws-eks/module-eks-node/launch_template_spot.tf
+++ b/terraform/aws-eks/module-eks-node/launch_template_spot.tf
@@ -18,6 +18,11 @@ resource "aws_launch_template" "eks-node-spot" {
     }
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 2
+  }
+
   network_interfaces {
     associate_public_ip_address = var.node_associate_public_ip_address
     delete_on_termination       = true

--- a/terraform/aws-eks/module-eks-node/launch_template_spot.tf
+++ b/terraform/aws-eks/module-eks-node/launch_template_spot.tf
@@ -13,8 +13,8 @@ resource "aws_launch_template" "eks-node-spot" {
     market_type = "spot"
 
     spot_options {
-      spot_instance_type = "one-time"
-      max_price          = var.node_spot_price
+      spot_instance_type = var.node_spot_request_type != "" ? var.node_spot_request_type : null
+      max_price          = var.node_spot_price != "" ? var.node_spot_price : null
     }
   }
 

--- a/terraform/aws-eks/module-eks-node/nodes.tf
+++ b/terraform/aws-eks/module-eks-node/nodes.tf
@@ -83,7 +83,7 @@ data "template_file" "user-data-eks-node" {
     apiserver_endpoint = var.control_plane_endpoint
     b64_cluster_ca     = var.control_plane_ca
     cluster_name       = var.cluster_name
-    bootstrap_args     = "--kubelet-extra-args --node-labels=node.kubernetes.io/nodegroup=${var.node_group_name},node.kubernetes.io/lifecycle=%{ if var.node_launch_template_profile == "spot" }Ec2Spot%{ else }OnDemand%{ endif },node.cycloid.io/customer=${var.customer},node.cycloid.io/project=${var.project},node.cycloid.io/env=${var.env}"
+    bootstrap_args     = "--kubelet-extra-args --node-labels=node.kubernetes.io/nodegroup=${var.node_group_name},node.kubernetes.io/lifecycle=%{ if var.node_launch_template_profile == "spot" }Ec2Spot%{ else }OnDemand%{ endif },node.cycloid.io/customer=${var.customer},node.cycloid.io/project=${var.project},node.cycloid.io/env=${var.env},eks.amazonaws.com/capacityType=%{ if var.node_launch_template_profile == "spot" }SPOT%{ else }ON_DEMAND%{ endif },eks.amazonaws.com/nodegroup=${var.node_group_name},eks.amazonaws.com/nodegroup-image=${data.aws_ami.eks-node.id}"
   }
 }
 

--- a/terraform/aws-eks/module-eks-node/nodes.tf
+++ b/terraform/aws-eks/module-eks-node/nodes.tf
@@ -112,9 +112,9 @@ resource "aws_cloudformation_stack" "eks-node" {
         "DesiredCapacity": "${var.node_count}",
         "MinSize": "${var.node_asg_min_size}",
         "MaxSize": "${var.node_asg_max_size}",
-        "TerminationPolicies": ["OldestLaunchConfiguration", "NewestInstance"],
+        "TerminationPolicies": ["AllocationStrategy", "OldestLaunchTemplate", "OldestInstance"],
         "HealthCheckType": "EC2",
-        "HealthCheckGracePeriod": 600,
+        "HealthCheckGracePeriod": 15,
         "MetricsCollection": [{
           "Granularity": "1Minute",
           "Metrics": ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity", "GroupInServiceInstances", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]

--- a/terraform/aws-eks/module-eks-node/nodes.tf
+++ b/terraform/aws-eks/module-eks-node/nodes.tf
@@ -17,7 +17,9 @@ resource "aws_security_group" "eks-node" {
   tags = merge(local.merged_tags, {
     Name                           = "${var.project}-${var.env}-eks-node-${var.node_group_name}"
     role                           = "eks-node"
-    "kubernetes.io/nodegroup/name" = "${var.node_group_name}"
+    "kubernetes.io/nodegroup/name" = var.node_group_name
+    "eks:cluster-name"             = var.cluster_name
+    "eks:nodegroup-name"           = var.node_group_name
   })
 }
 
@@ -47,9 +49,11 @@ locals {
     [
       { "Key" = "Name", "Value" = "${var.project}-${var.env}-eks-node-${var.node_group_name}", "PropagateAtLaunch" = "true" },
       { "Key" = "role", "Value" = "eks-node", "PropagateAtLaunch" = "true" },
-      { "Key" = "Spot", "Value" = "%{ if var.node_launch_template_profile == "spot" }true%{ else }false%{ endif }", "PropagateAtLaunch" = "true" },
+      { "Key" = "Spot", "Value" = "%{if var.node_launch_template_profile == "spot"}true%{else}false%{endif}", "PropagateAtLaunch" = "true" },
       { "Key" = "kubernetes.io/cluster/${var.cluster_name}", "Value" = "owned", "PropagateAtLaunch" = "true" },
-      { "Key" = "kubernetes.io/nodegroup/name", "Value" = "${var.node_group_name}", "PropagateAtLaunch" = "true" }
+      { "Key" = "kubernetes.io/nodegroup/name", "Value" = var.node_group_name, "PropagateAtLaunch" = "true" },
+      { "Key" = "eks:cluster-name", "Value" = var.cluster_name, "PropagateAtLaunch" = "true" },
+      { "Key" = "eks:nodegroup-name", "Value" = var.node_group_name, "PropagateAtLaunch" = "true" }
     ],
     [
       for tag in keys(local.cluster_autoscaler_tags) :
@@ -83,7 +87,7 @@ data "template_file" "user-data-eks-node" {
     apiserver_endpoint = var.control_plane_endpoint
     b64_cluster_ca     = var.control_plane_ca
     cluster_name       = var.cluster_name
-    bootstrap_args     = "--kubelet-extra-args --node-labels=node.kubernetes.io/nodegroup=${var.node_group_name},node.kubernetes.io/lifecycle=%{ if var.node_launch_template_profile == "spot" }Ec2Spot%{ else }OnDemand%{ endif },node.cycloid.io/customer=${var.customer},node.cycloid.io/project=${var.project},node.cycloid.io/env=${var.env},eks.amazonaws.com/capacityType=%{ if var.node_launch_template_profile == "spot" }SPOT%{ else }ON_DEMAND%{ endif },eks.amazonaws.com/nodegroup=${var.node_group_name},eks.amazonaws.com/nodegroup-image=${data.aws_ami.eks-node.id}"
+    bootstrap_args     = "--kubelet-extra-args --node-labels=node.kubernetes.io/nodegroup=${var.node_group_name},node.kubernetes.io/lifecycle=%{if var.node_launch_template_profile == "spot"}Ec2Spot%{else}OnDemand%{endif},node.cycloid.io/customer=${var.customer},node.cycloid.io/project=${var.project},node.cycloid.io/env=${var.env},eks.amazonaws.com/capacityType=%{if var.node_launch_template_profile == "spot"}SPOT%{else}ON_DEMAND%{endif},eks.amazonaws.com/nodegroup=${var.node_group_name},eks.amazonaws.com/nodegroup-image=${data.aws_ami.eks-node.id}"
   }
 }
 

--- a/terraform/aws-eks/module-eks-node/templates/userdata.sh.tpl
+++ b/terraform/aws-eks/module-eks-node/templates/userdata.sh.tpl
@@ -34,5 +34,7 @@ export AWS_UNIQUE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 /etc/eks/bootstrap.sh \
     --apiserver-endpoint '${apiserver_endpoint}' \
     --b64-cluster-ca '${b64_cluster_ca}' \
+    --dns-cluster-ip 172.20.0.10 \
+    --use-max-pods false \
     '${cluster_name}' \
     ${bootstrap_args} 2>&1 >> $LOG_FILE

--- a/terraform/aws-eks/module-eks-node/variables.tf
+++ b/terraform/aws-eks/module-eks-node/variables.tf
@@ -111,7 +111,7 @@ variable "node_group_name" {
 
 variable "node_launch_template_profile" {
   description = "EKS nodes profile, can be either `ondemand` or `spot`."
-  default = "ondemand"
+  default     = "ondemand"
 }
 
 variable "node_launch_template_id" {

--- a/terraform/aws-eks/module-eks-node/variables.tf
+++ b/terraform/aws-eks/module-eks-node/variables.tf
@@ -122,9 +122,14 @@ variable "node_launch_template_latest_version" {
   default = ""
 }
 
+variable "node_spot_request_type" {
+  description = "EKS nodes spot request type when `node_market_type = spot`. Can be either `one-time`, `persistent` or left undefined."
+  default     = ""
+}
+
 variable "node_spot_price" {
-  description = "EKS nodes spot price when `node_market_type = spot`."
-  default     = "0.3"
+  description = "EKS nodes max spot price when `node_market_type = spot`. Undefined by default."
+  default     = ""
 }
 
 variable "node_type" {

--- a/terraform/aws-eks/module-eks/k8s_aws_auth.tf
+++ b/terraform/aws-eks/module-eks/k8s_aws_auth.tf
@@ -10,6 +10,10 @@ resource "kubernetes_config_map" "aws_auth" {
           groups:
             - system:bootstrappers
             - system:nodes
+        - rolearn: ${local.k8s_eks_admin_iam_role_arn}
+          username: admin
+          groups:
+            - system:masters
 MAPROLES
   }
 

--- a/terraform/aws-eks/module-eks/k8s_console_rbac.tf
+++ b/terraform/aws-eks/module-eks/k8s_console_rbac.tf
@@ -1,0 +1,118 @@
+# ref. https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+
+resource "kubernetes_cluster_role" "eks-console-dashboard-full-access" {
+  metadata {
+    name = "eks-console-dashboard-full-access-clusterrole"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["nodes", "namespaces", "pods"]
+    verbs      = ["get", "list"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    verbs      = ["get", "list"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["cronjobs", "jobs"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "eks-console-dashboard-full-access" {
+  metadata {
+    name = "eks-console-dashboard-full-access-binding"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "eks-console-dashboard-full-access-clusterrole"
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = "eks-console-dashboard-full-access-group"
+  }
+}
+
+resource "kubernetes_cluster_role" "eks-console-dashboard-restricted-access" {
+  metadata {
+    name = "eks-console-dashboard-restricted-access-clusterrole"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["nodes", "namespaces"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "eks-console-dashboard-restricted-access-clusterrole" {
+  metadata {
+    name = "eks-console-dashboard-restricted-access-clusterrole-binding"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "eks-console-dashboard-restricted-access-clusterrole"
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = "eks-console-dashboard-restricted-access-group"
+  }
+}
+
+resource "kubernetes_role" "eks-console-dashboard-restricted-access-default" {
+  metadata {
+    name      = "eks-console-dashboard-restricted-access-role"
+    namespace = "default"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["nodes", "namespaces", "pods"]
+    verbs      = ["get", "list"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    verbs      = ["get", "list"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["cronjobs", "jobs"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_role_binding" "eks-console-dashboard-restricted-access-role-default" {
+  metadata {
+    name      = "eks-console-dashboard-restricted-access-role-binding"
+    namespace = "default"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "eks-console-dashboard-restricted-access-role"
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = "eks-console-dashboard-restricted-access-group"
+  }
+}
+

--- a/terraform/aws-eks/module-eks/variables.tf
+++ b/terraform/aws-eks/module-eks/variables.tf
@@ -86,3 +86,13 @@ variable "control_plane_allowed_ips" {
   description = "Allow Inbound IP CIDRs to access the Kubernetes API."
   default     = ["0.0.0.0/0"]
 }
+
+locals {
+  k8s_eks_admin_iam_role_arn = var.eks_admin_iam_role_arn != "" ? var.eks_admin_iam_role_arn : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"
+}
+
+variable "eks_admin_iam_role_arn" {
+  description = "AWS IAM role ARN to map as system:masters within the Kubernetes cluster. By default, a default arbitrary role called 'admin' will be allowed."
+  default     = ""
+}
+


### PR DESCRIPTION
- Add the recommended ClusterRole and Role documented by AWS to give specific roles and users permissions to view EKS workloads through the AWS console.
- Add AWS IAM role binding to the Kubernetes `system:masters` group to make the EKS workload viewable from the AWS console by "admins" + add a new `eks_admin_iam_role_arn` variable to let the user choose which role to bind it to. By default, the arbitrary `admin` role will be chosen, even if the role doesn't exist.
- Based on my testing, I added newly discovered `eks.amazonaws.com` k8s node labels and `eks:*` AWS resource tags.
- Set some configurations the same way AWS is configuring its nodegroup when creating them from the AWS console.