### PR TITLE
terraform/scaleway-kapsule: docker container_runtine is deprecated

### DIFF
--- a/terraform/scaleway-kapsule/module-node-pool/variables.tf
+++ b/terraform/scaleway-kapsule/module-node-pool/variables.tf
@@ -110,7 +110,7 @@ variable enable_autohealing {
 variable container_runtime {
   type        = string
   description = "The container runtime of the pool. Important: Updates to this field will recreate a new resource."
-  default     = "docker"
+  default     = "containerd"
 }
 
 variable placement_group_id {


### PR DESCRIPTION
```
Error: scaleway-sdk-go: invalid argument(s): container_runtime does not respect constraint, docker is deprecated. see https://kubernetes.io/blog/2020/12/02/dockershim-faq/
```