### PR TITLE
aks: commenting potential useless depends on

### DIFF
--- a/terraform/azure-aks/aks.tf.sample
+++ b/terraform/azure-aks/aks.tf.sample
@@ -67,9 +67,9 @@ module "vpc" {
   resource_group_name = module.config.azurerm_resource_group_name
   location            = module.config.azurerm_resource_group_location
 
-  depends_on = [
-    module.config,
-  ]
+  #depends_on = [
+  #  module.config,
+  #]
 }
 
 module "aks" {
@@ -216,9 +216,9 @@ module "aks" {
   service_principal_client_id     = var.aks_service_principal_client_id
   service_principal_client_secret = var.aks_service_principal_client_secret
 
-  depends_on = [
-    module.config,
-  ]
+  #depends_on = [
+  #  module.config,
+  #]
 }
 
 # You can duplicate this module to create mutiple AKS node groups.


### PR DESCRIPTION
Goal is to make this stack compatible with stackforms.
And module.config seems to raise a Terraform HCL error right now

HCL has an invalid format: file "azure-aks.terraform.aks.content": module.config: module variables must be three parts: module.name.attr in: ${module.config}